### PR TITLE
Bugfix abs retrieval multi gpu

### DIFF
--- a/evaluation/MTEB/examples/evaluate_model.py
+++ b/evaluation/MTEB/examples/evaluate_model.py
@@ -4,29 +4,28 @@ import logging
 import argparse
 from mteb import MTEB
 from InstructorEmbedding import INSTRUCTOR
+if __name__ == '__main__':
+    logging.basicConfig(level=logging.INFO)
+    parser = argparse.ArgumentParser()
+    parser.add_argument('--model_name', default=None,type=str)
+    parser.add_argument('--output_dir', default=None,type=str)
+    parser.add_argument('--task_name', default=None,type=str)
+    parser.add_argument('--cache_dir', default=None,type=str)
+    parser.add_argument('--result_file', default=None,type=str)
+    parser.add_argument('--prompt', default=None,type=str)
+    parser.add_argument('--split', default='test',type=str)
+    parser.add_argument('--batch_size', default=128,type=int)
+    args = parser.parse_args()
 
-logging.basicConfig(level=logging.INFO)
+    if not args.result_file.endswith('.txt') and not os.path.isdir(args.result_file):
+        os.makedirs(args.result_file,exist_ok=True)
 
-parser = argparse.ArgumentParser()
-parser.add_argument('--model_name', default=None,type=str)
-parser.add_argument('--output_dir', default=None,type=str)
-parser.add_argument('--task_name', default=None,type=str)
-parser.add_argument('--cache_dir', default=None,type=str)
-parser.add_argument('--result_file', default=None,type=str)
-parser.add_argument('--prompt', default=None,type=str)
-parser.add_argument('--split', default='test',type=str)
-parser.add_argument('--batch_size', default=-1,type=int)
-args = parser.parse_args()
+    # from tqdm import tqdm
+    # from functools import partialmethod
+    #
+    # tqdm.__init__ = partialmethod(tqdm.__init__, disable=True)
+    model = INSTRUCTOR(args.model_name,cache_folder=args.cache_dir)
+    evaluation = MTEB(tasks=[args.task_name],task_langs=["en"])
+    evaluation.run(model, output_folder=args.output_dir, eval_splits=[args.split],args=args,)
 
-if not args.result_file.endswith('.txt') and not os.path.isdir(args.result_file):
-    os.makedirs(args.result_file,exist_ok=True)
-
-# from tqdm import tqdm
-# from functools import partialmethod
-#
-# tqdm.__init__ = partialmethod(tqdm.__init__, disable=True)
-model = INSTRUCTOR(args.model_name,cache_folder=args.cache_dir)
-evaluation = MTEB(tasks=[args.task_name],task_langs=["en"])
-evaluation.run(model, output_folder=args.output_dir, eval_splits=[args.split],args=args,)
-
-print("--DONE--")
+    print("--DONE--")

--- a/evaluation/MTEB/mteb/abstasks/BeIRTask.py
+++ b/evaluation/MTEB/mteb/abstasks/BeIRTask.py
@@ -17,13 +17,10 @@ class BeIRTask(AbsTask):
         except ImportError:
             raise Exception("Retrieval tasks require beir package. Please install it with `pip install mteb[beir]`")
 
-        USE_BEIR_DEVELOPMENT = False
         try:
             if self.description["beir_name"].startswith("cqadupstack"):
                 raise ImportError("CQADupstack is incompatible with latest BEIR")
             from beir.datasets.data_loader_hf import HFDataLoader as BeirDataLoader
-
-            USE_BEIR_DEVELOPMENT = True
         except ImportError:
             from beir.datasets.data_loader import GenericDataLoader as BeirDataLoader
 
@@ -36,18 +33,11 @@ class BeIRTask(AbsTask):
 
         self.corpus, self.queries, self.relevant_docs = {}, {}, {}
         for split in eval_splits:
-            if USE_BEIR_DEVELOPMENT:
-                self.corpus[split], self.queries[split], self.relevant_docs[split] = BeirDataLoader(
-                    hf_repo=f"BeIR/{dataset}"
-                ).load(split=split)
-            else:
-                url = f"https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/{dataset}.zip"
-                # download_path = os.path.join(datasets.config.HF_DATASETS_CACHE, "BeIR")
-                download_path = os.path.join('/home2/huggingface/datasets', "BeIR")
-                # download_path = os.path.join('/gscratch/zlab/swj0419', "BeIR")
-                data_path = util.download_and_unzip(url, download_path)
-                data_path = f"{data_path}/{sub_dataset}" if sub_dataset else data_path
-                self.corpus[split], self.queries[split], self.relevant_docs[split] = BeirDataLoader(
-                    data_folder=data_path
-                ).load(split=split)
+            url = f"https://public.ukp.informatik.tu-darmstadt.de/thakur/BEIR/datasets/{dataset}.zip"
+            download_path = os.path.join(datasets.config.HF_DATASETS_CACHE, "BeIR")
+            data_path = util.download_and_unzip(url, download_path)
+            data_path = f"{data_path}/{sub_dataset}" if sub_dataset else data_path
+            self.corpus[split], self.queries[split], self.relevant_docs[split] = BeirDataLoader(
+                data_folder=data_path
+            ).load(split=split)
         self.data_loaded = True

--- a/evaluation/MTEB/mteb/evaluation/MTEB.py
+++ b/evaluation/MTEB/mteb/evaluation/MTEB.py
@@ -237,7 +237,7 @@ class MTEB:
                 }
                 for split in task_eval_splits:
                     tick = time()
-                    results = task.evaluate(model, split, **kwargs)
+                    results = task.evaluate(model, split, batch_size=my_args.batch_size, **kwargs)
                     tock = time()
                     logger.info(f"Evaluation for {task.description['name']} on {split} took {tock - tick:.2f} seconds")
                     results["evaluation_time"] = round(tock - tick, 2)

--- a/evaluation/MTEB/setup.py
+++ b/evaluation/MTEB/setup.py
@@ -38,8 +38,8 @@ To create the package for pypi.
 
 
 from setuptools import find_packages, setup
-print(find_packages())
-exit(0)
+# print(find_packages())
+# exit(0)
 
 
 with open("README.md", mode="r", encoding="utf-8") as readme_file:
@@ -74,6 +74,7 @@ setup(
     python_requires=">=3.7.0",
     install_requires=[
         "datasets>=2.2.0",
+        "pyarrow==8.0.0",
         "jsonlines",
         "numpy",
         "requests>=2.26.0",

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 transformers==4.20.0
 datasets>=2.2.0
+pyarrow==8.0.0
 jsonlines
 numpy
 requests>=2.26.0


### PR DESCRIPTION
Issues fixed:

1. When debugging the evalution_model.py in multi_gpu case, there occurs a debugger port collision between collision between parent and child processes. In order to avoid this: nested the evaluation_model.py within name == 'main'.
2. The expected behaviour of sentence_transformer_encode_multi_process_worker() function is to encode the corpus, evaluate the score against all the queries and store the metric. This was not properly handled by this function. Hence made use of the default SentenceTransformer._encode_multi_process_worker().
3. Appended instruction in sentences list in encode_corpus_parallel(). This change is made with reference taken from encode_corpus() function.
4. USE_BEIR_DEVELOPMENT is removed from evaluation/MTEB/mteb/abstasks/BeIRTask.py. This boolean just skips cqadupstack dataset download. I do not find any valid reason to do so. Hence removed.
5. Added explicit requirement pyarrow==8.0.0. Pip auto dependency resolver installs the latest version of pyarrow and that does not play well with the evaluate package.
6. Added necessary changes in train.py in order to feed in validation dataset.